### PR TITLE
PouchDB-Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.db

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/eHealthAfrica/kazana-example#readme",
   "dependencies": {
-    "kazana": "^1.1.3"
+    "kazana": "^1.2.0"
   },
   "devDependencies": {
     "semantic-release": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/eHealthAfrica/kazana-example#readme",
   "dependencies": {
-    "kazana": "^1.0.1"
+    "kazana": "^1.1.3"
   },
   "devDependencies": {
     "semantic-release": "^3.3.2",


### PR DESCRIPTION
This PR depends on https://github.com/eHealthAfrica/kazana/pull/9.
No `npm link` is needed, it's already installed via the package.json
(needs to be fixed before merging.)

@obdulia-losantos could you please give this a try? What should happen is
that when you run `npm start`, it will not connect to your local CouchDB,
instead it will spawn a PouchDB Server at http://localhost:4999 and
connect to it. The goal is to remove the dependency for CouchDB (at least
in local development), and to stop messing with peoples local CouchDB
installations.

Let me know what you think :)